### PR TITLE
Add python3 dependencies to bindep.txt

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -2,3 +2,6 @@
 # see http://docs.openstack.org/infra/bindep/ for additional information.
 
 gcc-c++ [doc test platform:rpm]
+python3-devel [test platform:rpm]
+python3 [test platform:rpm]
+python36 [test !platform:fedora-28]


### PR DESCRIPTION
This is helpful when we bring online fedora-29 images.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>