### PR TITLE
Enable strict mode for yamllint

### DIFF
--- a/changelogs/fragments/v0-initial-release.yaml
+++ b/changelogs/fragments/v0-initial-release.yaml
@@ -1,3 +1,4 @@
+---
 major_changes:
   - Initial release of the ``cloud_vpn`` Ansible role.
   - This role provides functions to manage IPSEC VPN tunnels.

--- a/changelogs/fragments/v261-fix-meta-suffix.yaml
+++ b/changelogs/fragments/v261-fix-meta-suffix.yaml
@@ -1,2 +1,3 @@
+---
 minor_changes:
   - Rename meta/main.yaml to meta/main.yml to avoid Galaxy upload issues.

--- a/changelogs/fragments/v262-decouple-providers-provisioners.yaml
+++ b/changelogs/fragments/v262-decouple-providers-provisioners.yaml
@@ -1,2 +1,3 @@
+---
 minor_changes:
   - Decouple provisioners and providers on their own roles, which will be available from Galaxy.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,7 +19,7 @@ galaxy_info:
   # this branch. If Travis integration is configured, only notifications for this
   # branch will be accepted. Otherwise, in all cases, the repo's default branch
   # (usually master) will be used.
-  #github_branch:
+  # github_branch:
 
   platforms:
     - name: GenericLinux

--- a/tests/test_aws_csr_to_aws_vpn.yaml
+++ b/tests/test_aws_csr_to_aws_vpn.yaml
@@ -1,6 +1,7 @@
+---
 - hosts: localhost
   connection: local
-  gather_facts: no
+  gather_facts: false
 
   vars_files:
     - "{{ playbook_dir }}/secrets.yaml"
@@ -65,7 +66,7 @@
             security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
             region: "{{ cloud_vpn_initiator_aws_region }}"
           register: out
-          no_log: True
+          no_log: false
 
         - copy:
             dest: "{{ cloud_vpn_initiator_ssh_private_key_file }}"

--- a/tests/test_aws_csr_to_aws_vpn_bgp.yaml
+++ b/tests/test_aws_csr_to_aws_vpn_bgp.yaml
@@ -1,6 +1,7 @@
+---
 - hosts: localhost
   connection: local
-  gather_facts: no
+  gather_facts: false
 
   vars_files:
     - "{{ playbook_dir }}/secrets.yaml"
@@ -66,7 +67,7 @@
             security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
             region: "{{ cloud_vpn_initiator_aws_region }}"
           register: out
-          no_log: True
+          no_log: true
 
         - copy:
             dest: "{{ cloud_vpn_initiator_ssh_private_key_file }}"

--- a/tests/test_aws_csr_to_aws_vyos.yaml
+++ b/tests/test_aws_csr_to_aws_vyos.yaml
@@ -1,6 +1,7 @@
+---
 - hosts: localhost
   connection: local
-  gather_facts: no
+  gather_facts: false
 
   vars_files:
     - "{{ playbook_dir }}/secrets.yaml"
@@ -60,7 +61,7 @@
             security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
             region: "{{ cloud_vpn_initiator_aws_region }}"
           register: out
-          no_log: True
+          no_log: true
 
         - copy:
             dest: "{{ cloud_vpn_initiator_ssh_private_key_file }}"

--- a/tests/test_aws_vyos_to_aws_vpn.yaml
+++ b/tests/test_aws_vyos_to_aws_vpn.yaml
@@ -1,6 +1,7 @@
+---
 - hosts: localhost
   connection: local
-  gather_facts: no
+  gather_facts: false
 
   vars_files:
     - "{{ playbook_dir }}/secrets.yaml"
@@ -65,7 +66,7 @@
             security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
             region: "{{ cloud_vpn_initiator_aws_region }}"
           register: out
-          no_log: True
+          no_log: true
 
         - copy:
             dest: "{{ cloud_vpn_initiator_ssh_private_key_file }}"

--- a/tests/test_aws_vyos_to_aws_vyos.yaml
+++ b/tests/test_aws_vyos_to_aws_vyos.yaml
@@ -1,6 +1,7 @@
+---
 - hosts: localhost
   connection: local
-  gather_facts: no
+  gather_facts: false
 
   vars_files:
     - "{{ playbook_dir }}/secrets.yaml"
@@ -61,7 +62,7 @@
             security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
             region: "{{ cloud_vpn_initiator_aws_region }}"
           register: out
-          no_log: True
+          no_log: true
 
         - copy:
             dest: "{{ cloud_vpn_initiator_ssh_private_key_file }}"

--- a/tests/test_aws_vyos_to_aws_vyos_bgp.yaml
+++ b/tests/test_aws_vyos_to_aws_vyos_bgp.yaml
@@ -1,6 +1,7 @@
+---
 - hosts: localhost
   connection: local
-  gather_facts: no
+  gather_facts: false
 
   vars_files:
     - "{{ playbook_dir }}/secrets.yaml"
@@ -62,7 +63,7 @@
             security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
             region: "{{ cloud_vpn_initiator_aws_region }}"
           register: out
-          no_log: True
+          no_log: true
 
         - copy:
             dest: "{{ cloud_vpn_initiator_ssh_private_key_file }}"

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps = -r{toxinidir}/test-requirements.txt
 
 [testenv:linters]
 commands =
-  yamllint .
+  yamllint -s .
   flake8 {posargs}
 
 [testenv:venv]


### PR DESCRIPTION
This cleans up yamllint warnings, as we now consider them errors. This
should keep galaxy scoring happy when we import roles there.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>