### PR TITLE
Add feature to run post configure hooks

### DIFF
--- a/tasks/create_vpn.yaml
+++ b/tasks/create_vpn.yaml
@@ -32,6 +32,12 @@
 - name: Include configure routing initiator tasks
   include_tasks: configure_routing_initiator.yaml
 
+- name: Include post configure initiator hooks tasks
+  include_tasks: post_configure_initiator_hooks.yaml
+
+- name: Include post configure responder hooks tasks
+  include_tasks: post_configure_responder_hooks.yaml
+
 - name: Include show login info responder tasks
   include_tasks: show_login_info_responder.yaml
 

--- a/tasks/post_configure_initiator_hooks.yaml
+++ b/tasks/post_configure_initiator_hooks.yaml
@@ -1,3 +1,5 @@
+---
+
 - name: Include post configure initiator hooks tasks
   include_tasks: "{{ cloud_vpn_initiator_post_configure_hooks }}"
   when: cloud_vpn_initiator_post_configure_hooks is defined

--- a/tasks/post_configure_initiator_hooks.yaml
+++ b/tasks/post_configure_initiator_hooks.yaml
@@ -1,0 +1,3 @@
+- name: Include post configure initiator hooks tasks
+  include_tasks: "{{ cloud_vpn_initiator_post_configure_hooks }}"
+  when: cloud_vpn_initiator_post_configure_hooks is defined

--- a/tasks/post_configure_responder_hooks.yaml
+++ b/tasks/post_configure_responder_hooks.yaml
@@ -1,0 +1,3 @@
+- name: Include post configure responder hooks tasks
+  include_tasks: "{{ cloud_vpn_responder_post_configure_hooks }}"
+  when: cloud_vpn_responder_post_configure_hooks is defined

--- a/tasks/post_configure_responder_hooks.yaml
+++ b/tasks/post_configure_responder_hooks.yaml
@@ -1,3 +1,5 @@
+---
+
 - name: Include post configure responder hooks tasks
   include_tasks: "{{ cloud_vpn_responder_post_configure_hooks }}"
   when: cloud_vpn_responder_post_configure_hooks is defined


### PR DESCRIPTION
User just needs to provide a path to a task file and create_vpn
will just go thru it.

Signed-off-by: Ricardo Carrillo Cruz <ricardo.carrillo.cruz@gmail.com>